### PR TITLE
[fix] Change test config & add more assert

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,6 @@ config :sphinx, Sphinx.Repo,
   hostname: "localhost",
   username: "postgres",
   password: "postgres",
-  database: "sphinx",
+  database: "sphinx_test",
   port: "5432",
   pool: Ecto.Adapters.SQL.Sandbox

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -26,7 +26,7 @@ defmodule SphinxRtm.MessagesTest do
       {Slack.Web.Users, [], [info: fn "ABC" -> @user_a end]},
       {Slack.Web.Chat, [], [get_permalink: fn "XYZ", "123.456" -> @question_permalink end]}
     ]) do
-      {:ok, riddle} = Messages.process(@question)
+      assert {:ok, riddle} = Messages.process(@question)
       assert riddle.enquirer == get_user(@user_a)
       assert riddle.permalink == get_permalink(@question_permalink)
       assert riddle.title == @question.text
@@ -50,8 +50,8 @@ defmodule SphinxRtm.MessagesTest do
          end
        ]}
     ]) do
-      {:ok, _} = Messages.process(@question)
-      {:ok, riddle} = Messages.process(@answer)
+      assert {:ok, _} = Messages.process(@question)
+      assert {:ok, riddle} = Messages.process(@answer)
       assert riddle.enquirer == get_user(@user_a)
       assert riddle.solver == get_user(@user_b)
       assert riddle.permalink_answer == get_permalink(@answer_permalink)


### PR DESCRIPTION
Change database config in `test.exs` to "sphinx_test" so it won't blow up when I have something in the DB when I manually test the code with actual stuff from Slack

Also add assert in front of  '{:ok, _riddle }`in messages test