### PR TITLE
[add] Message is trimmed to get content when sphinx-bot is invoked

### DIFF
--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -16,11 +16,15 @@ defmodule SphinxRtm.Messages do
         :no_reply
 
       false ->
-        # TODO: check if @sphinx is invoked
         case Parser.mention_sphinx?(message.text) do
           true ->
-            process_question(message)
-            {:reply, "Are you asking for me?"}
+            message
+            |> Map.put(:text, Parser.trim_mention(message.text))
+            |> process_question()
+
+            # An ugly way to construct the reply but it will be changed in the future :)
+            {:reply,
+             "You asked for \"#{Parser.trim_mention(message.text)}\" but I have no answer!"}
 
           false ->
             :no_reply

--- a/lib/sphinx_rtm/parser.ex
+++ b/lib/sphinx_rtm/parser.ex
@@ -4,7 +4,7 @@ defmodule SphinxRtm.Messages.Parser do
 
   @spec mention_sphinx?(String.t()) :: boolean()
   def mention_sphinx?(text) do
-    with true <- String.match?(text, ~r/[<][@](.)*[>]/) do
+    with true <- String.match?(text, ~r/^[<@](.)*[>]/) do
       [mention_id | _content] = String.split(text, ["<@", ">"], trim: true)
       is_sphinx_id?(mention_id)
     else
@@ -17,4 +17,7 @@ defmodule SphinxRtm.Messages.Parser do
     user_name = SlackUtils.get_user_name(id)
     String.contains?(user_name, ["sphinx"])
   end
+
+  @spec trim_mention(String.t()) :: String.t()
+  def trim_mention(text), do: String.replace(text, ~r/[<@](.)*[>]\s/, "")
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -4,21 +4,27 @@ defmodule SphinxRtm.Messages.ParserTest do
 
   import Mock
 
-  @user%{"user" => %{"name" => "user_a", "id" => "ABC"}}
+  @user %{"user" => %{"name" => "user_a", "id" => "ABC"}}
   @sphinx %{"user" => %{"name" => "sphinx", "id" => "SPX"}}
 
-  describe "parser returns" do
-    test "true when message starts with @sphinx" do
-      message = "<@SPX> Hello"
-      with_mock(Slack.Web.Users, [info: fn "SPX" -> @sphinx end]) do
-        assert Parser.mention_sphinx?(message)
+  describe "parser checks if sphinx-bot is invoked and returns" do
+    test "true only when message starts with @sphinx" do
+      message1 = "<@SPX> Hello"
+      message2 = "Hello <@SPX>"
+
+      with_mock(Slack.Web.Users, info: fn "SPX" -> @sphinx end) do
+        assert Parser.mention_sphinx?(message1)
+        refute Parser.mention_sphinx?(message2)
       end
     end
 
     test "false when someone else is mentioned" do
-      message = "<@ABC> Hello"
-      with_mock(Slack.Web.Users, [info: fn "ABC" -> @user end]) do
-        refute Parser.mention_sphinx?(message)
+      message1 = "<@ABC> Hello"
+      message2 = "Hello <@ABC>"
+
+      with_mock(Slack.Web.Users, info: fn "ABC" -> @user end) do
+        refute Parser.mention_sphinx?(message1)
+        refute Parser.mention_sphinx?(message2)
       end
     end
 
@@ -26,5 +32,15 @@ defmodule SphinxRtm.Messages.ParserTest do
       message = "Hello"
       refute Parser.mention_sphinx?(message)
     end
+  end
+
+  test "parser trim message if user is mentioned first in a message" do
+    message1 = "<@SPX> Hello"
+    message2 = "Hello"
+    message3 = "Hello <@SPX>"
+
+    assert "Hello" = Parser.trim_mention(message1)
+    assert "Hello" = Parser.trim_mention(message2)
+    assert "Hello <@SPX>" = Parser.trim_mention(message3)
   end
 end


### PR DESCRIPTION
When `@sphinx` is mentioned, only the content comes after `@sphinx` is added to the database. The mention is omitted.