### PR TITLE
[fix] Saving a thread reply

### DIFF
--- a/lib/sphinx_rtm.ex
+++ b/lib/sphinx_rtm.ex
@@ -19,6 +19,7 @@ defmodule SphinxRtm do
   def handle_event(message = %{type: "message"}, slack, state) do
     user = SlackUtils.get_user_name(message.user)
     Logger.info("Processing message from #{user}")
+
     case Messages.process(message) do
       {:reply, text} ->
         send_message(text, message.channel, slack)


### PR DESCRIPTION
It was broken apparently as a thread's permalink has the extension of `?thread_ts=something` in its permalink and when we use it to seacrh for permalink in DB, it cannot find the right entry