### PR TITLE
[add] Reply to message as a thread

### DIFF
--- a/lib/sphinx_rtm.ex
+++ b/lib/sphinx_rtm.ex
@@ -21,8 +21,8 @@ defmodule SphinxRtm do
     Logger.info("Processing message from #{user}")
 
     case Messages.process(message) do
-      {:reply, text} ->
-        send_thread_message(text, message, slack)
+      {:reply, reply} ->
+        send_thread_reply(reply, message, slack)
         {:ok, state}
 
       :no_reply ->
@@ -42,12 +42,12 @@ defmodule SphinxRtm do
 
   def handle_info(_, _, state), do: {:ok, state}
 
-  def send_thread_message(reply, message, slack) do
+  def send_thread_reply(reply, received_message, slack) do
     %{
       type: "message",
       text: reply,
-      channel: message.channel,
-      thread_ts: message.ts
+      channel: received_message.channel,
+      thread_ts: received_message.ts
     }
     |> Poison.encode!()
     |> send_raw(slack)

--- a/lib/sphinx_rtm.ex
+++ b/lib/sphinx_rtm.ex
@@ -22,7 +22,7 @@ defmodule SphinxRtm do
 
     case Messages.process(message) do
       {:reply, text} ->
-        send_message(text, message.channel, slack)
+        send_thread_message(text, message, slack)
         {:ok, state}
 
       :no_reply ->
@@ -41,4 +41,15 @@ defmodule SphinxRtm do
   end
 
   def handle_info(_, _, state), do: {:ok, state}
+
+  def send_thread_message(reply, message, slack) do
+    %{
+      type: "message",
+      text: reply,
+      channel: message.channel,
+      thread_ts: message.ts
+    }
+    |> Poison.encode!()
+    |> send_raw(slack)
+  end
 end


### PR DESCRIPTION
Make sphinx-bot reply the question (when is invoked) under a thread rather than in an open channel.

This is to keep the relevant message/topic together and not populate the channel with too much bot messages.