### PR TITLE
[add] Update schema to store multiples answers

### DIFF
--- a/lib/sphinx/riddles/answer.ex
+++ b/lib/sphinx/riddles/answer.ex
@@ -1,0 +1,27 @@
+defmodule Sphinx.Riddles.Answer do
+  @moduledoc """
+    Riddle definition
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @timestamps_opts [type: :utc_datetime]
+  @required [:permalink, :solver]
+  @fields [:upvote] ++ @required
+
+  schema "answers" do
+    field(:permalink, :string)
+    field(:upvote, :integer)
+    field(:solver, :string)
+    belongs_to(:riddle, Sphinx.Riddles.Riddle)
+
+    timestamps()
+  end
+
+  def changeset(answer, params \\ %{}) do
+    answer
+    |> cast(params, @fields)
+    |> validate_required(@required)
+  end
+end

--- a/lib/sphinx/riddles/answer.ex
+++ b/lib/sphinx/riddles/answer.ex
@@ -1,4 +1,4 @@
-defmodule Sphinx.Riddles.Answer do
+defmodule Sphinx.Answers.Answer do
   @moduledoc """
     Riddle definition
   """

--- a/lib/sphinx/riddles/answer.ex
+++ b/lib/sphinx/riddles/answer.ex
@@ -1,7 +1,5 @@
 defmodule Sphinx.Answers.Answer do
-  @moduledoc """
-    Riddle definition
-  """
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/sphinx/riddles/answers.ex
+++ b/lib/sphinx/riddles/answers.ex
@@ -1,0 +1,61 @@
+defmodule Sphinx.Answers do
+  alias Sphinx.Riddles.Riddle
+  alias Sphinx.Riddles.Answer
+  alias Sphinx.Repo
+
+  require Logger
+
+  @spec create(map(), Riddle.t()) :: {:ok, Answer.t()} | {:error, Ecto.Changeset.t()}
+  def create(params, riddle) when is_map(params) do
+    riddle
+    |> Ecto.build_assoc(:answers)
+    |> Answer.changeset(params)
+    |> Repo.insert()
+  end
+
+  @spec all(Riddle.t()) :: list()
+  def all(riddle) do
+    riddle
+    |> Ecto.assoc(:answers)
+    |> Repo.all()
+  end
+
+  @spec get(map(), Riddle.t()) :: Answer.t() | nil
+  def get(%{id: id} = params, riddle) when is_map(params) do
+    riddle
+    |> Ecto.assoc(:answers)
+    |> Repo.get_by(id: id)
+  end
+
+  def get(%{permalink: permalink} = params, riddle) when is_map(params) do
+    riddle
+    |> Ecto.assoc(:answers)
+    |> Repo.get_by(permalink: permalink)
+  end
+
+  def get(_), do: nil
+
+  @spec delete(map(), Riddle.t()) :: {:ok, Answer.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def delete(params, riddle) when is_map(params) do
+    case get(params, riddle) do
+      nil ->
+        {:error, :not_found}
+
+      answer ->
+        Repo.delete(answer)
+    end
+  end
+
+  @spec update(map(), Riddle.t()) :: {:ok, Riddle.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+  def update(params, riddle) when is_map(params) do
+    case get(params, riddle) do
+      nil ->
+        {:error, :not_found}
+
+      answer ->
+        answer
+        |> Answer.changeset(params)
+        |> Repo.update()
+    end
+  end
+end

--- a/lib/sphinx/riddles/answers.ex
+++ b/lib/sphinx/riddles/answers.ex
@@ -1,6 +1,6 @@
 defmodule Sphinx.Answers do
   alias Sphinx.Riddles.Riddle
-  alias Sphinx.Riddles.Answer
+  alias Sphinx.Answers.Answer
   alias Sphinx.Repo
 
   require Logger
@@ -20,24 +20,20 @@ defmodule Sphinx.Answers do
     |> Repo.all()
   end
 
-  @spec get(map(), Riddle.t()) :: Answer.t() | nil
-  def get(%{id: id} = params, riddle) when is_map(params) do
-    riddle
-    |> Ecto.assoc(:answers)
-    |> Repo.get_by(id: id)
+  @spec get(map()) :: Answer.t() | nil
+  def get(%{id: id} = params) when is_map(params) do
+    Repo.get_by(Answer, id: id)
   end
 
-  def get(%{permalink: permalink} = params, riddle) when is_map(params) do
-    riddle
-    |> Ecto.assoc(:answers)
-    |> Repo.get_by(permalink: permalink)
+  def get(%{permalink: permalink} = params) when is_map(params) do
+    Repo.get_by(Answer, permalink: permalink)
   end
 
   def get(_), do: nil
 
-  @spec delete(map(), Riddle.t()) :: {:ok, Answer.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
-  def delete(params, riddle) when is_map(params) do
-    case get(params, riddle) do
+  @spec delete(map()) :: {:ok, Answer.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def delete(params) when is_map(params) do
+    case get(params) do
       nil ->
         {:error, :not_found}
 
@@ -46,9 +42,9 @@ defmodule Sphinx.Answers do
     end
   end
 
-  @spec update(map(), Riddle.t()) :: {:ok, Riddle.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
-  def update(params, riddle) when is_map(params) do
-    case get(params, riddle) do
+  @spec update(map()) :: {:ok, Riddle.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+  def update(params) when is_map(params) do
+    case get(params) do
       nil ->
         {:error, :not_found}
 

--- a/lib/sphinx/riddles/riddle.ex
+++ b/lib/sphinx/riddles/riddle.ex
@@ -15,7 +15,7 @@ defmodule Sphinx.Riddles.Riddle do
     field(:permalink, :string)
     field(:keywords, {:array, :string})
     field(:enquirer, :string)
-    has_many(:answers, Sphinx.Riddles.Answer)
+    has_many(:answers, Sphinx.Answers.Answer)
 
     timestamps()
   end

--- a/lib/sphinx/riddles/riddle.ex
+++ b/lib/sphinx/riddles/riddle.ex
@@ -8,16 +8,14 @@ defmodule Sphinx.Riddles.Riddle do
 
   @timestamps_opts [type: :utc_datetime]
   @required [:permalink, :enquirer]
-  @fields [:title, :keywords, :permalink_answer, :upvote, :enquirer, :solver] ++ @required
+  @fields [:title, :keywords, :enquirer] ++ @required
 
   schema "riddles" do
     field(:title, :string)
     field(:permalink, :string)
     field(:keywords, {:array, :string})
-    field(:permalink_answer, :string)
-    field(:upvote, :integer)
     field(:enquirer, :string)
-    field(:solver, :string)
+    has_many(:answers, Sphinx.Riddles.Answer)
 
     timestamps()
   end

--- a/lib/sphinx/riddles/riddles.ex
+++ b/lib/sphinx/riddles/riddles.ex
@@ -24,9 +24,7 @@ defmodule Sphinx.Riddles do
       :title,
       :permalink,
       :keywords,
-      :upvote,
-      :enquirer,
-      :solver
+      :enquirer
     ])
     |> Repo.paginate(params)
   end

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -1,5 +1,4 @@
 defmodule SphinxRtm.Messages do
-
   alias SphinxRtm.Messages.Parser
   alias Sphinx.Riddles
   alias Sphinx.SlackUtils
@@ -51,8 +50,12 @@ defmodule SphinxRtm.Messages do
   @spec save_reply(map()) :: {:ok, Riddles.Riddle.t()} | {:error, Ecto.Changeset.t()} | :ok
   defp save_reply(message) do
     params = %{:permalink => get_thread_permalink(message.channel, message.thread_ts)}
+
     case Riddles.get(params) do
-      nil -> :ok #Ignore thread reply to not-saved messages
+      # Ignore thread reply to not-saved messages
+      nil ->
+        :ok
+
       question ->
         %{}
         |> Map.put(:solver, user(message.user))

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -1,7 +1,9 @@
 defmodule SphinxRtm.Messages do
+
   alias SphinxRtm.Messages.Parser
   alias Sphinx.Riddles
   alias Sphinx.SlackUtils
+  alias Sphinx.Answers
 
   ## TODO: check if message is a question
   ## if yes then get the keywords and search for old questions
@@ -48,11 +50,14 @@ defmodule SphinxRtm.Messages do
 
   @spec save_reply(map()) :: {:ok, Riddles.Riddle.t()} | {:error, Ecto.Changeset.t()}
   defp save_reply(message) do
+    question =
+      %{:permalink => get_thread_permalink(message.channel, message.thread_ts)}
+      |> Riddles.get()
+
     %{}
     |> Map.put(:solver, user(message.user))
-    |> Map.put(:permalink_answer, permalink(message.channel, message.ts))
-    |> Map.put(:permalink, get_thread_permalink(message.channel, message.thread_ts))
-    |> Riddles.update()
+    |> Map.put(:permalink, permalink(message.channel, message.ts))
+    |> Answers.create(question)
   end
 
   defp user(user_id), do: SlackUtils.get_user_name(user_id)

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -48,16 +48,17 @@ defmodule SphinxRtm.Messages do
     |> Riddles.create()
   end
 
-  @spec save_reply(map()) :: {:ok, Riddles.Riddle.t()} | {:error, Ecto.Changeset.t()}
+  @spec save_reply(map()) :: {:ok, Riddles.Riddle.t()} | {:error, Ecto.Changeset.t()} | :ok
   defp save_reply(message) do
-    question =
-      %{:permalink => get_thread_permalink(message.channel, message.thread_ts)}
-      |> Riddles.get()
-
-    %{}
-    |> Map.put(:solver, user(message.user))
-    |> Map.put(:permalink, permalink(message.channel, message.ts))
-    |> Answers.create(question)
+    params = %{:permalink => get_thread_permalink(message.channel, message.thread_ts)}
+    case Riddles.get(params) do
+      nil -> :ok #Ignore thread reply to not-saved messages
+      question ->
+        %{}
+        |> Map.put(:solver, user(message.user))
+        |> Map.put(:permalink, permalink(message.channel, message.ts))
+        |> Answers.create(question)
+    end
   end
 
   defp user(user_id), do: SlackUtils.get_user_name(user_id)

--- a/priv/repo/migrations/20191205195511_create_riddle.exs
+++ b/priv/repo/migrations/20191205195511_create_riddle.exs
@@ -6,10 +6,7 @@ defmodule Sphinx.Repo.Migrations.CreateRiddle do
       add :title, :string, null: true
       add :permalink, :string, null: false
       add :keywords, {:array, :string}
-      add :permalink_answer, :string, null: true
-      add :upvote, :integer, default: 0
       add :enquirer, :string, null: false
-      add :solver, :string, null: true
       add :created_at, :utc_datetime, default: fragment("NOW()")
 
       timestamps()

--- a/priv/repo/migrations/20191216145627_create_answer.exs
+++ b/priv/repo/migrations/20191216145627_create_answer.exs
@@ -1,0 +1,14 @@
+defmodule Sphinx.Repo.Migrations.CreateAnswer do
+  use Ecto.Migration
+
+  def change do
+    create table(:answers) do
+      add :permalink, :string, null: false
+      add :upvote, :integer, default: 0
+      add :solver, :string, null: false
+      add :riddle_id, references(:riddles)
+
+      timestamps()
+    end
+  end
+end

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -96,7 +96,9 @@ defmodule SphinxRtm.MessagesTest do
       ]) do
         question = %{@question | text: "<@SPX> 5eb63bbbe01eeed093cb22bb8f5acdc3"}
         assert {:reply, response} = Messages.process(question)
-        assert "You asked for \"5eb63bbbe01eeed093cb22bb8f5acdc3\" but I have no answer!" =~ response
+
+        assert "You asked for \"5eb63bbbe01eeed093cb22bb8f5acdc3\" but I have no answer!" =~
+                 response
       end
     end
   end

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -8,6 +8,7 @@ defmodule SphinxRtm.MessagesTest do
   alias Sphinx.Repo
   alias Sphinx.Riddles
   alias Sphinx.Riddles.Riddle
+  alias Sphinx.Answers
 
   @question %{type: "message", channel: "XYZ", ts: "123.456", user: "ABC", text: "<@SPX> Hello"}
   @answer %{
@@ -125,9 +126,10 @@ defmodule SphinxRtm.MessagesTest do
         assert :no_reply = Messages.process(@answer)
 
         [riddle] = Repo.all(Riddle)
+        [answer] = Answers.all(riddle)
         assert riddle.enquirer == get_user(@user_a)
-        assert riddle.solver == get_user(@user_b)
-        assert riddle.permalink_answer == get_permalink(@answer_permalink)
+        assert answer.solver == get_user(@user_b)
+        assert answer.permalink == get_permalink(@answer_permalink)
       end
     end
 

--- a/test/sphinx/riddles/answer_test.exs
+++ b/test/sphinx/riddles/answer_test.exs
@@ -1,0 +1,49 @@
+defmodule Sphinx.Riddles.AnswerTest do
+
+  use ExUnit.Case
+
+  alias Sphinx.Answers.Answer
+
+  @params %{
+    permalink: "permalink",
+    upvote: 1,
+    solver: "A_USER"
+  }
+
+  describe "permalink field" do
+    test "is required" do
+      changeset = Answer.changeset(%Answer{}, Map.delete(@params, :permalink))
+      refute changeset.valid?
+      assert changeset.errors == [permalink: {"can't be blank", [validation: :required]}]
+    end
+    test "is an string" do
+      changeset = Answer.changeset(%Answer{}, @params)
+      assert changeset.valid?
+    end
+  end
+
+  describe "upvote field" do
+    test "is not required" do
+      changeset = Answer.changeset(%Answer{}, Map.delete(@params, :upvote))
+      assert changeset.valid?
+    end
+
+    test "is an integer" do
+      changeset = Answer.changeset(%Answer{}, @params)
+      assert changeset.valid?
+    end
+  end
+
+  describe "solver field" do
+    test "is  required" do
+      changeset = Answer.changeset(%Answer{}, Map.delete(@params, :solver))
+      refute changeset.valid?
+      assert changeset.errors == [solver: {"can't be blank", [validation: :required]}]
+    end
+
+    test "is an string" do
+      changeset = Answer.changeset(%Answer{}, @params)
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/sphinx/riddles/answer_test.exs
+++ b/test/sphinx/riddles/answer_test.exs
@@ -1,5 +1,4 @@
 defmodule Sphinx.Riddles.AnswerTest do
-
   use ExUnit.Case
 
   alias Sphinx.Answers.Answer
@@ -16,6 +15,7 @@ defmodule Sphinx.Riddles.AnswerTest do
       refute changeset.valid?
       assert changeset.errors == [permalink: {"can't be blank", [validation: :required]}]
     end
+
     test "is an string" do
       changeset = Answer.changeset(%Answer{}, @params)
       assert changeset.valid?

--- a/test/sphinx/riddles/answers_test.exs
+++ b/test/sphinx/riddles/answers_test.exs
@@ -121,5 +121,4 @@ defmodule Sphinx.AnswersTest do
       assert {:error, :not_found} = Answers.update(@answer_params)
     end
   end
-
 end

--- a/test/sphinx/riddles/answers_test.exs
+++ b/test/sphinx/riddles/answers_test.exs
@@ -1,0 +1,125 @@
+defmodule Sphinx.AnswersTest do
+  use Sphinx.Support.DataCase
+
+  alias Sphinx.Answers
+  alias Sphinx.Answer.Answer
+  alias Sphinx.Riddles
+
+  @question_params %{
+    title: "title",
+    permalink: "question_permalink",
+    keywords: ["keyword", "key", "word"],
+    enquirer: "A_USER"
+  }
+
+  @answer_params %{
+    permalink: "answer_permalink",
+    upvote: 1,
+    solver: "B_USER"
+  }
+
+  describe "Answers.create/2" do
+    test "works with correct params" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      assert [] = Answers.all(riddle)
+      assert {:ok, answer} = Answers.create(@answer_params, riddle)
+      assert answer.permalink == @answer_params.permalink
+      assert answer.upvote == @answer_params.upvote
+      assert answer.upvote == @answer_params.upvote
+    end
+
+    test "fails with wrong params" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      assert {:error, changeset} = Answers.create(Map.delete(@answer_params, :permalink), riddle)
+      refute changeset.valid?
+    end
+  end
+
+  describe "Answers.all/1" do
+    test "returns all answers belong to a riddle" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, answer1} = Answers.create(@answer_params, riddle)
+      {:ok, answer2} = Answers.create(%{@answer_params | permalink: "answer_permalink2"}, riddle)
+
+      result = Answers.all(riddle)
+
+      assert Enum.member?(result, answer1)
+      assert Enum.member?(result, answer2)
+    end
+  end
+
+  describe "Answers.get/1" do
+    test "returns answers if exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, answer} = Answers.create(@answer_params, riddle)
+      assert answer == Answers.get(%{permalink: @answer_params.permalink})
+    end
+
+    test "returns nil if no answer exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      assert [] == Answers.all(riddle)
+
+      refute Answers.get(%{permalink: @answer_params.permalink})
+    end
+
+    test "returns nil if answer with specific parameter does not exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, _answer} = Answers.create(@answer_params, riddle)
+
+      refute Answers.get(%{permalink: "some_link"})
+    end
+  end
+
+  describe "Answer.delete/1" do
+    test "deletes answer successfully if exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, answer} = Answers.create(@answer_params, riddle)
+      assert [answer] == Answers.all(riddle)
+      assert {:ok, deleted_answer} = Answers.delete(%{permalink: @answer_params.permalink})
+      assert answer.id == deleted_answer.id
+      assert [] = Answers.all(riddle)
+    end
+
+    test "returns error if no answer exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      assert [] = Answers.all(riddle)
+      assert {:error, :not_found} == Answers.delete(%{permalink: @answer_params.permalink})
+    end
+
+    test "returns error if answer with specific parameter does not exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, _answer} = Answers.create(@answer_params, riddle)
+      assert {:error, :not_found} == Answers.delete(%{permalink: "Some_link"})
+    end
+  end
+
+  describe "Answers.update/1" do
+    test "updates an answer if exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, answer} = Answers.create(@answer_params, riddle)
+
+      new_params = %{@answer_params | upvote: 3}
+
+      assert {:ok, updated_answer} = Answers.update(new_params)
+      assert answer.id == updated_answer.id
+      assert updated_answer.upvote == 3
+    end
+
+    test "does not update with wrong parameters" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      {:ok, answer} = Answers.create(@answer_params, riddle)
+
+      new_params = %{@answer_params | upvote: "three"}
+
+      assert {:error, changeset} = Answers.update(new_params)
+      refute changeset.valid?
+    end
+
+    test "does not update when answer does not exists" do
+      {:ok, riddle} = Riddles.create(@question_params)
+      assert [] == Answers.all(riddle)
+      assert {:error, :not_found} = Answers.update(@answer_params)
+    end
+  end
+
+end

--- a/test/sphinx/riddles/riddle_test.exs
+++ b/test/sphinx/riddles/riddle_test.exs
@@ -7,7 +7,7 @@ defmodule Sphinx.Riddles.RiddleTest do
     title: "title",
     permalink: "permalink",
     keywords: ["keyword", "key", "word"],
-    enquirer: "A_USER",
+    enquirer: "A_USER"
   }
 
   describe "permalink field" do

--- a/test/sphinx/riddles/riddle_test.exs
+++ b/test/sphinx/riddles/riddle_test.exs
@@ -6,11 +6,8 @@ defmodule Sphinx.Riddles.RiddleTest do
   @params %{
     title: "title",
     permalink: "permalink",
-    permalink_answer: "answer",
     keywords: ["keyword", "key", "word"],
-    upvote: 1,
     enquirer: "A_USER",
-    solver: "B_USER"
   }
 
   describe "permalink field" do
@@ -57,58 +54,11 @@ defmodule Sphinx.Riddles.RiddleTest do
     end
   end
 
-  describe "permalink_answer field" do
-    test "is not required" do
-      changeset = Riddle.changeset(%Riddle{}, Map.delete(@params, :permalink_answer))
-      assert changeset.valid?
-    end
-
-    test "is an string" do
-      changeset = Riddle.changeset(%Riddle{}, @params)
-      assert changeset.valid?
-    end
-
-    test "different than string must fail" do
-      params = %{@params | permalink_answer: 123}
-      changeset = Riddle.changeset(%Riddle{}, params)
-
-      refute changeset.valid?
-
-      assert changeset.errors == [
-               permalink_answer: {"is invalid", [type: :string, validation: :cast]}
-             ]
-    end
-  end
-
-  describe "upvote field" do
-    test "is not required" do
-      changeset = Riddle.changeset(%Riddle{}, Map.delete(@params, :upvote))
-      assert changeset.valid?
-    end
-
-    test "is an integer" do
-      changeset = Riddle.changeset(%Riddle{}, @params)
-      assert changeset.valid?
-    end
-  end
-
   describe "enquirer field" do
     test "is required" do
       changeset = Riddle.changeset(%Riddle{}, Map.delete(@params, :enquirer))
       refute changeset.valid?
       assert changeset.errors == [enquirer: {"can't be blank", [validation: :required]}]
-    end
-
-    test "is an string" do
-      changeset = Riddle.changeset(%Riddle{}, @params)
-      assert changeset.valid?
-    end
-  end
-
-  describe "solver field" do
-    test "is not required" do
-      changeset = Riddle.changeset(%Riddle{}, Map.delete(@params, :solver))
-      assert changeset.valid?
     end
 
     test "is an string" do

--- a/test/sphinx/riddles/riddles_test.exs
+++ b/test/sphinx/riddles/riddles_test.exs
@@ -8,11 +8,8 @@ defmodule Sphinx.RiddlesTest do
   @params %{
     title: "title",
     permalink: "permalink",
-    permalink_answer: "answer",
     keywords: ["keyword", "key", "word"],
-    upvote: 1,
     enquirer: "A_USER",
-    solver: "B_USER"
   }
 
   describe "Riddles.create/1" do
@@ -23,9 +20,7 @@ defmodule Sphinx.RiddlesTest do
       assert riddle.title == @params.title
       assert riddle.permalink == @params.permalink
       assert riddle.keywords == @params.keywords
-      assert riddle.upvote == @params.upvote
       assert riddle.enquirer == @params.enquirer
-      assert riddle.solver == @params.solver
     end
 
     test "fails with wrong params" do
@@ -49,11 +44,8 @@ defmodule Sphinx.RiddlesTest do
       params = %{
         title: "title_II",
         permalink: "permalink_II",
-        permalink_answer: "answer_II",
         keywords: ["other", "another", "word"],
-        upvote: 5,
         enquirer: "A_USER",
-        solver: "B_USER_II"
       }
 
       {:ok, riddle1} = Riddles.create(@params)

--- a/test/sphinx/riddles/riddles_test.exs
+++ b/test/sphinx/riddles/riddles_test.exs
@@ -9,7 +9,7 @@ defmodule Sphinx.RiddlesTest do
     title: "title",
     permalink: "permalink",
     keywords: ["keyword", "key", "word"],
-    enquirer: "A_USER",
+    enquirer: "A_USER"
   }
 
   describe "Riddles.create/1" do
@@ -74,7 +74,7 @@ defmodule Sphinx.RiddlesTest do
       assert riddle == Riddles.get(%{id: id, title: @params.title})
     end
 
-    test "return nil if riddle not exist" do
+    test "returns nil if riddle not exist" do
       assert [] == Repo.all(Riddle)
 
       refute Riddles.get(%{id: 1001, title: ""})
@@ -98,7 +98,7 @@ defmodule Sphinx.RiddlesTest do
   end
 
   describe "Riddles.update/1" do
-    test "update a riddle if is ok" do
+    test "updates a riddle if is ok" do
       {:ok, riddle} = Riddles.create(@params)
       assert riddle
 
@@ -111,7 +111,7 @@ defmodule Sphinx.RiddlesTest do
       assert updated.title == "title_II"
     end
 
-    test "updating a riddle by permalink" do
+    test "updates a riddle by permalink" do
       {:ok, riddle} = Riddles.create(@params)
       assert riddle
 
@@ -122,7 +122,7 @@ defmodule Sphinx.RiddlesTest do
       assert updated.title == "title_II"
     end
 
-    test "do not update with wrong params" do
+    test "does not update with wrong params" do
       {:ok, riddle} = Riddles.create(@params)
       assert riddle
 
@@ -137,7 +137,7 @@ defmodule Sphinx.RiddlesTest do
              ]
     end
 
-    test "do not update if do not exist" do
+    test "does not update if do not exist" do
       assert [] == Repo.all(Riddle)
       params = Map.put(@params, :id, 101)
       assert {:error, :not_found} = Riddles.update(params)

--- a/test/sphinx/riddles/riddles_test.exs
+++ b/test/sphinx/riddles/riddles_test.exs
@@ -45,7 +45,7 @@ defmodule Sphinx.RiddlesTest do
         title: "title_II",
         permalink: "permalink_II",
         keywords: ["other", "another", "word"],
-        enquirer: "A_USER",
+        enquirer: "A_USER"
       }
 
       {:ok, riddle1} = Riddles.create(@params)


### PR DESCRIPTION
Add 'answers' schema to store multiple answers in a question thread, this way, we can store different answers and count their votes individually