### PR TITLE
[add] Thumbsup reaction counts

### DIFF
--- a/lib/sphinx/riddles/answer.ex
+++ b/lib/sphinx/riddles/answer.ex
@@ -1,5 +1,4 @@
 defmodule Sphinx.Answers.Answer do
-
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/sphinx_rtm.ex
+++ b/lib/sphinx_rtm.ex
@@ -30,6 +30,12 @@ defmodule SphinxRtm do
     end
   end
 
+  def handle_event(message = %{type: "reaction_added", reaction: "+1"}, _slack, state) do
+    Logger.info("Thumbsup reaction received")
+    Messages.add_reaction(message)
+    {:ok, state}
+  end
+
   def handle_event(_, _, state), do: {:ok, state}
 
   def handle_info({:message, text, channel}, slack, state) do

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -55,7 +55,9 @@ defmodule SphinxRtm.Messages do
     permalink = permalink(message.item.channel, message.item.ts)
 
     case Answers.get(%{permalink: permalink}) do
-      nil -> :ok
+      nil ->
+        :ok
+
       answer ->
         upvote = answer.upvote
         Answers.update(%{permalink: permalink, upvote: upvote + 1})

--- a/lib/sphinx_rtm/messages.ex
+++ b/lib/sphinx_rtm/messages.ex
@@ -51,6 +51,17 @@ defmodule SphinxRtm.Messages do
     end
   end
 
+  def add_reaction(message) do
+    permalink = permalink(message.item.channel, message.item.ts)
+
+    case Answers.get(%{permalink: permalink}) do
+      nil -> :ok
+      answer ->
+        upvote = answer.upvote
+        Answers.update(%{permalink: permalink, upvote: upvote + 1})
+    end
+  end
+
   @spec save_question(map()) :: {:ok, Riddles.Riddle.t()} | {:error, Ecto.Changeset.t()}
   defp save_question(message) do
     %{}

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -26,7 +26,8 @@ defmodule SphinxRtm.MessagesTest do
   @reaction %{
     type: "reaction_added",
     reaction: "+1",
-    item: %{type: "message", channel: "XYZ", ts: "124.456"}}
+    item: %{type: "message", channel: "XYZ", ts: "124.456"}
+  }
 
   @question_permalink %{"permalink" => "https://fake_question_http"}
   @question_thread_permalink %{
@@ -169,8 +170,7 @@ defmodule SphinxRtm.MessagesTest do
 
   describe "thumbsup reaction to a message" do
     test "is counted when it is an answer for saved question" do
-
-      #Fake the answer data
+      # Fake the answer data
       answer_params = %{solver: "user_b", permalink: get_permalink(@answer_permalink)}
 
       {:ok, riddle} = Riddles.create(@thread_riddle)
@@ -179,7 +179,7 @@ defmodule SphinxRtm.MessagesTest do
 
       with_mock(Slack.Web.Chat,
         get_permalink: fn
-             "XYZ", "124.456" -> @answer_permalink
+          "XYZ", "124.456" -> @answer_permalink
         end
       ) do
         assert {:ok, new_answer} = Messages.add_reaction(@reaction)

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -23,6 +23,11 @@ defmodule SphinxRtm.MessagesTest do
   @user_b %{"user" => %{"name" => "user_b", "id" => "DEF"}}
   @sphinx %{"user" => %{"name" => "sphinx", "id" => "SPX"}}
 
+  @reaction %{
+    type: "reaction_added",
+    reaction: "+1",
+    item: %{type: "message", channel: "XYZ", ts: "124.456"}}
+
   @question_permalink %{"permalink" => "https://fake_question_http"}
   @question_thread_permalink %{
     "permalink" => "https://fake_question_http?thread_ts=fake_question_http"
@@ -158,6 +163,39 @@ defmodule SphinxRtm.MessagesTest do
         assert :no_reply = Messages.process(@answer)
 
         [] = Repo.all(Riddle)
+      end
+    end
+  end
+
+  describe "thumbsup reaction to a message" do
+    test "is counted when it is an answer for saved question" do
+
+      #Fake the answer data
+      answer_params = %{solver: "user_b", permalink: get_permalink(@answer_permalink)}
+
+      {:ok, riddle} = Riddles.create(@thread_riddle)
+      {:ok, answer} = Answers.create(answer_params, riddle)
+      answer = Answers.get(%{id: answer.id})
+
+      with_mock(Slack.Web.Chat,
+        get_permalink: fn
+             "XYZ", "124.456" -> @answer_permalink
+        end
+      ) do
+        assert {:ok, new_answer} = Messages.add_reaction(@reaction)
+        assert new_answer.upvote == answer.upvote + 1
+      end
+    end
+
+    test "is not counted when message is not saved" do
+      with_mock(Slack.Web.Chat,
+        get_permalink: fn
+          "XYZ", "124.456" -> @answer_permalink
+        end
+      ) do
+        {:ok, riddle} = Riddles.create(@thread_riddle)
+        assert [] == Answers.all(riddle)
+        assert :ok = Messages.add_reaction(@reaction)
       end
     end
   end

--- a/test/sphinx/riddles/answers_test.exs
+++ b/test/sphinx/riddles/answers_test.exs
@@ -2,7 +2,6 @@ defmodule Sphinx.AnswersTest do
   use Sphinx.Support.DataCase
 
   alias Sphinx.Answers
-  alias Sphinx.Answer.Answer
   alias Sphinx.Riddles
 
   @question_params %{
@@ -107,7 +106,7 @@ defmodule Sphinx.AnswersTest do
 
     test "does not update with wrong parameters" do
       {:ok, riddle} = Riddles.create(@question_params)
-      {:ok, answer} = Answers.create(@answer_params, riddle)
+      {:ok, _answer} = Answers.create(@answer_params, riddle)
 
       new_params = %{@answer_params | upvote: "three"}
 


### PR DESCRIPTION
When a "+1" reaction is added, sphinx checks if the message is saved in a thread (indicates it is an answer for a question), if yes, Sphinx will iterate the number of upvotes, else, ignores.