### PR TITLE
[add] Sort search query result by their upvote

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,9 @@
 use Mix.Config
 
-config :slack, api_token: System.get_env("OAUTH_ACCESS_TOKEN")
+config :slack,
+  api_token: System.get_env("OAUTH_ACCESS_TOKEN"),
+  user_token: System.get_env("USER_OAUTH_ACCESS_TOKEN"),
+  slack_url: "https://slack.com/api/"
 
 config :sphinx,
   owner_username: "sphinx",


### PR DESCRIPTION
Use Slack.Web.Reactions to get the reactions of a message from query result and get the "+1" count from the result. If there is no reaction or no "+1" reaction, returns 0. Using the count, we can sort the message by most to least upvotes.

Also add user token key and slack url key to dev config. Else others when getting the code cannot test manually on Slack